### PR TITLE
Change test/report lifecycle

### DIFF
--- a/test/assertions-test.ts
+++ b/test/assertions-test.ts
@@ -1,4 +1,4 @@
-import { testcase, subcase } from '../dist/ducktest.js';
+import { testcase, subcase, tap } from '../dist/ducktest.js';
 import { soften, silence } from '../dist/assertions.js';
 import { strict as assert } from 'assert';
 

--- a/test/ducktest-test.ts
+++ b/test/ducktest-test.ts
@@ -1,14 +1,14 @@
 import { strict as assert } from 'assert';
-import { testcase, subcase, assertions, suite, tap } from '../dist/ducktest.js';
+import { testcase, subcase, assertions, report, tap, suite } from '../dist/ducktest.js';
 
-testcase('make a new suite', async () => {
+testcase('make a new report', async () => {
     let output: string[] = [];
-    const reporter = tap(line => output.push(line));
-    const s = suite(reporter);
+    const stream = (line: string) => output.push(line);
+    const s = suite();
 
     subcase('run an empty test', async () => {
         await s.testcase('empty test', () => { });
-        reporter.end();
+        await s.report(stream);
         assert.deepEqual(output, [
             'ok - empty test'
         ]);
@@ -18,7 +18,7 @@ testcase('make a new suite', async () => {
         await s.testcase('failing test', () => {
             s.assertions.softFail(new Error('failure'));
         });
-        reporter.end();
+        await s.report(stream);
         assert.deepEqual(output, [
             '# failing test',
             '    not ok - failure',
@@ -33,7 +33,7 @@ testcase('make a new suite', async () => {
             s.subcase('subcase one', () => { });
             s.subcase('subcase two', () => { });
         });
-        reporter.end();
+        await s.report(stream);
         assert.deepEqual(output, [
             '# passing test',
             '    ok - subcase one',
@@ -49,7 +49,7 @@ testcase('make a new suite', async () => {
             });
             s.subcase('empty subcase', () => { });
         });
-        reporter.end();
+        await s.report(stream);
         assert.deepEqual(output, [
             '# test',
             '    # failing subcase',
@@ -70,7 +70,7 @@ testcase('make a new suite', async () => {
             });
             s.subcase('empty subcase', () => { });
         });
-        reporter.end();
+        await s.report(stream);
         assert.deepEqual(output, [
             '# test',
             '    not ok - failure',


### PR DESCRIPTION
Tests used to run immediately upon invocation of `testcase` function.
The motivation for this was that it's easy to reason about, there is
no non-local execution of tests so we can setup our test fixtures
inline with the `testcase` in the root of a module/script.

But this had a couple of problems:

- If in future there is a mechanism to "skip" tests by filtering on
thier description, there would be no way to skip over setup/teardown
in the root scope.

- TAP output to stdout assumes sole ownership of the output stream,
as anything else may break the output. But if TAP tests are run from
many different modules at different times there is no well defined
scope for this ownership in immediate mode. If ducktest wants to e.g.
replace stdout for the duration of the output there is no nice way
to do this, the options are to preemptively wrap stdout as soon as
the ducktest module first runs (terrible!) or to wait until the first
test function is called (messy!).

- Responsibility for individual test output and responsibility for
"end of report" output (e.g. plan output, 1..n) are completely
separate from one another, making it hard to understand when and
where things happen. How do we know when all the tests have been
run? Who is responsible for making that determination?

For these reasons ducktest has been refactored so that `testcase`
merely *plans* a test. To execute the test and output a report
there is a new "report" function which optionally takes an output
stream and a reporter implementation as parameters.

This has a few positive effects;

- It better decouples reporting from testing, by not asking for a
reporter up-front before planning the test begins.

- It properly confines test output to a single (async) function
call, thus making it more reasonable to assert ownership of the
output stream.

- It gathers responsibility for report output to a single place.

By default when running in node, any tests planned for the
"default" suite (i.e. using the `testcase` `subcase` functions
exported from the module rather than creating new instances of
those functions by calling `suite` manually) a report is made to
stdout upon exit.

Further work:

Now `beforeAll` and `afterAll` style fixtures can't be set up
and torn down inline with calls to `testcase` in the root scope,
so we will ideally need a new `fixture` function to plan tests
which behave like this.