### PR TITLE
fixes #9 by intercepting console output when using the default stream

### DIFF
--- a/src/tap-output.ts
+++ b/src/tap-output.ts
@@ -4,44 +4,55 @@ export enum Ordering {
     Concurrent,
     Serial
 }
-export interface Reporter {
-    beginSubtest(desc: string, ordering?: Ordering): Reporter;
+
+export type Reporter = (stream: Stream) => Report;
+export interface Report {
+    beginSubtest(desc: string, ordering?: Ordering): Report;
     diagnostic(message: string): void;
     fail(cause: any): void;
     end(message?: string): void;
     success: boolean;
 };
-export type Stream = (line: string) => void;
-export function tap(writeLine: Stream): Reporter {
-    return new TapReporter(writeLine);
+export interface Stream {
+    open?(): void;
+    close?(): void;
+    write(line: string): void;
+};
+export function tap(writeLine: Stream): Report {
+    return new TapReport(writeLine);
 };
 
-class TapReporter implements Reporter {
-    _write: Stream;
+class TapReport implements Report {
+    _stream: Stream;
     _ended = false;
     _ongoingSubtests = {
         [Ordering.Concurrent]: 0,
         [Ordering.Serial]: 0
     };
     success = true;
-    constructor(writeLine: Stream) {
-        this._write = writeLine;
+    constructor(stream: Stream) {
+        this._stream = stream;
+        if (this._stream.open) this._stream.open();
     }
-    beginSubtest(description: string, ordering = Ordering.Serial): Reporter {
-        return new TapSubReporter(this, description, ordering);
+    beginSubtest(description: string, ordering = Ordering.Serial): Report {
+        return new TapSubReport(this, description, ordering);
     }
-    diagnostic(message?: string) { this._write('# ' + message); }
+    diagnostic(message?: string) { this._stream.write('# ' + message); }
     fail(cause: any) {
         this.success = false;
-        this._write(`not ok${cause?.message ? ' - ' + cause.message : ''}`)
-        this._write('  ---');
-        this._write('  ...');
+        this._stream.write(`not ok${cause?.message ? ' - ' + cause.message : ''}`)
+        this._stream.write('  ---');
+        this._stream.write('  ...');
     }
     end(message?: string) {
-        if (this._ended) throw new TestError('already ended!');
-        if (this._ongoingSubtests[Ordering.Concurrent] + this._ongoingSubtests[Ordering.Serial]) throw new TestError('subtests not ended');
-        this._ended = true;
-        this._endMessage(message);
+        try {
+            if (this._ended) throw new TestError('already ended!');
+            if (this._ongoingSubtests[Ordering.Concurrent] + this._ongoingSubtests[Ordering.Serial]) throw new TestError('subtests not ended');
+            this._ended = true;
+            this._endMessage(message);
+        } finally {
+            if (this._stream.close) this._stream.close();
+        }
     }
     _endMessage(message?: string) {
         if (message != null) {
@@ -50,31 +61,31 @@ class TapReporter implements Reporter {
     }
 }
 
-class TapSubReporter extends TapReporter {
-    #parent: TapReporter;
+class TapSubReport extends TapReport {
+    #parent: TapReport;
     #description: string;
     #ordering: Ordering;
-    constructor(parent: TapReporter, description: string, ordering: Ordering) {
+    constructor(parent: TapReport, description: string, ordering: Ordering) {
         parent._ongoingSubtests[ordering]++;
 
         const o = ordering;
         let hasContent = false;
         const prefix = ordering == Ordering.Concurrent ? `  ${description}|  ` : '    ';
-        const writeLine = (line: string) => {
+        const write = (line: string) => {
             if (o === Ordering.Serial && !hasContent) {
                 hasContent = true;
                 parent.diagnostic(description);
             }
-            parent._write(prefix + line);
+            parent._stream.write(prefix + line);
         };
-        super(writeLine);
+        super({ write });
         this.#parent = parent;
         this.#description = description;
         this.#ordering = ordering;
     }
     _endMessage(message?: string) {
         this.#parent._ongoingSubtests[this.#ordering as Ordering]--;
-        this.#parent._write(`${this.success ? 'ok' : 'not ok'} - ${this.#description}${message ? ' # ' + message : ''}`);
+        this.#parent._stream.write(`${this.success ? 'ok' : 'not ok'} - ${this.#description}${message ? ' # ' + message : ''}`);
         this.#parent.success &&= this.success;
     }
 }

--- a/test/ducktest-test.ts
+++ b/test/ducktest-test.ts
@@ -1,9 +1,9 @@
 import { strict as assert } from 'assert';
-import { testcase, subcase, assertions, report, tap, suite } from '../dist/ducktest.js';
+import { testcase, subcase, assertions, report, tap, suite, Stream } from '../dist/ducktest.js';
 
 testcase('make a new report', async () => {
     let output: string[] = [];
-    const stream = (line: string) => output.push(line);
+    const stream: Stream = { write(line) { output.push(line); } };
     const s = suite();
 
     subcase('run an empty test', async () => {

--- a/test/tap-output-test.ts
+++ b/test/tap-output-test.ts
@@ -6,7 +6,7 @@ const assert: typeof strict = assertions.silence(strict);
 
 testcase('start a report', async () => {
     let output: string[] = [];
-    const report = tap(line => output.push(line));
+    const report = tap({ write(line) { output.push(line); } });
 
     subcase('end the report', () => {
         report.end();


### PR DESCRIPTION
Some minor refactoring was needed to support this, mainly that a
"Stream" is nolonger just a function taking a line:string, it also
has an "open" and a "close" function.