### PR TITLE
revert PR #9

### DIFF
--- a/src/ducktest.ts
+++ b/src/ducktest.ts
@@ -1,7 +1,7 @@
 export * from './assertions.js';
 import { soften, silence } from './assertions.js';
 export { Ordering, Reporter, Report, Stream, tap } from './tap-output.js';
-import { Ordering, Reporter, Report, Stream, tap, prepend } from './tap-output.js';
+import { Ordering, Reporter, Report, Stream, tap } from './tap-output.js';
 import { TestError } from './test-error.js';
 
 type Spec = () => Promise<void> | void;
@@ -47,18 +47,7 @@ function makeTestcaseState(baseReport: Report): TestcaseState {
     };
 }
 
-export const defaultStream: Stream = {
-    write: () => { },
-    open() {
-        this.write = console.log;
-        console.log = line => {
-            this.write(prepend('# ', line));
-        };
-    },
-    close() {
-        console.log = this.write;
-    }
-};
+export const defaultStream: Stream = console.log;
 export const defaultReporter: Reporter = tap;
 export function suite() {
     async function nextPass(state: TestcaseState, desc: string, spec: Spec): Promise<string> {
@@ -200,4 +189,3 @@ export const report = s.report.bind(s);
 if (process?.on) {
     process?.on('exit', () => report());
 }
-

--- a/test/ducktest-test.ts
+++ b/test/ducktest-test.ts
@@ -3,7 +3,7 @@ import { testcase, subcase, assertions, report, tap, suite, Stream } from '../di
 
 testcase('make a new report', async () => {
     let output: string[] = [];
-    const stream: Stream = { write(line) { output.push(line); } };
+    const stream: Stream = line => output.push(line);
     const s = suite();
 
     subcase('run an empty test', async () => {

--- a/test/tap-output-test.ts
+++ b/test/tap-output-test.ts
@@ -5,14 +5,13 @@ import { tap, Ordering, Stream, Reporter } from '../dist/tap-output.js';
 const assert: typeof strict = assertions.silence(strict);
 
 testcase('start a report', async () => {
-    let output: string[] = [];
-    const report = tap({
-        write(lines) {
-            for (const line of lines.split('\n')) {
-                output.push(line);
-            }
+    const output: string[] = [];
+    const stream: Stream = lines => {
+        for (const line of lines.split('\n')) {
+            output.push(line);
         }
-    });
+    };
+    const report = tap(stream);
 
     subcase('end the report', () => {
         report.end();
@@ -41,6 +40,14 @@ testcase('start a report', async () => {
             '    # two',
             '    # three',
             'ok - subtest'
+        ]);
+    });
+
+    subcase('emit output on original stream while report is in progress', () => {
+        stream('stream output')
+        report.end();
+        assert.deepEqual(output, [
+            'stream output'
         ]);
     });
 });


### PR DESCRIPTION
Unfortunately this fix introduced a coupling between the default
output stream and the TAP format, by making the stream substitute
console log with a version that was aware of the TAP diagnostic
format.

The first shot at fixing this allowed the "write" property on
Stream to be optionally settable, then the tap reporter was made
responsible for making the substitution ... but thinking about it
it seems that there are other problems here:

- there are multiple ways to skin this cat; perhaps a
user would prefer to just completely suppress other log output?
Or to redirect it to a file? the tap reporter shouldn't make this
choice.

- the substitution is only made for the duration of the report
output, which still leaves the application free to throw out
whatever it wants before and after the report, which will still
break output.

- this still didn't deal with console.error, etc. or
process.stdout in node.

So all in all it was a bunch of extra complexity for a partial
solution. Now that the report lifecycle is already clearly managed
by the user, opening and closing a stream can be done at the call
site of `report` rather than fussing around with callbacks. And
wrapping a stream---which may require an entirely different
lifecycle---can be managaed elsewhere as appropriate for a particular
app/platform.