### PR TITLE
Fixes #8 - throw TestError causes Bail out!

### DIFF
--- a/src/tap-output.ts
+++ b/src/tap-output.ts
@@ -13,6 +13,7 @@ export interface Report {
     diagnostic(message: string): void;
     fail(cause: any): void;
     end(message?: string): void;
+    bailOut(cause?: any): void;
     success: boolean;
 };
 export interface Stream {
@@ -52,6 +53,9 @@ class TapReport implements Report {
         if (this._ongoingSubtests[Ordering.Concurrent] + this._ongoingSubtests[Ordering.Serial]) throw new TestError('subtests not ended');
         this._ended = true;
         this._endMessage(message);
+    }
+    bailOut(cause?: any) {
+        this._stream(`Bail out!${cause?.message ? (' ' + cause.message) : ''}`)
     }
     _endMessage(message?: string) {
         if (message != null) {

--- a/test/ducktest-test.ts
+++ b/test/ducktest-test.ts
@@ -1,5 +1,6 @@
 import { strict as assert } from 'assert';
 import { testcase, subcase, assertions, report, tap, suite, Stream } from '../dist/ducktest.js';
+import { TestError } from '../dist/test-error.js';
 
 testcase('make a new report', async () => {
     let output: string[] = [];
@@ -79,6 +80,35 @@ testcase('make a new report', async () => {
             '    ok - failing subcase # SKIP enclosing case failed',
             '    ok - empty subcase # SKIP enclosing case failed',
             'not ok - test'
+        ]);
+    });
+
+    subcase('bail out of a test case after a message', async () => {
+        await s.testcase('test', () => {
+            s.message('message');
+            throw new TestError('cause');
+        });
+        await s.report(stream);
+        assert.deepEqual(output, [
+            '# test',
+            '    # message',
+            'Bail out! cause'
+        ]);
+    });
+
+    subcase('bail out of a subcase after a message', async () => {
+        await s.testcase('test', () => {
+            s.subcase('subcase', () => {
+                s.message('message');
+                throw new TestError('cause');
+            });
+        });
+        await s.report(stream);
+        assert.deepEqual(output, [
+            '# test',
+            '    # subcase',
+            '        # message',
+            'Bail out! cause'
         ]);
     });
 });


### PR DESCRIPTION
Added bail out to reporter interface and implemented for TAP

TestError now cascades to root of suite and bails out.