### PR TITLE
improved support for TAP format

### DIFF
--- a/test/ducktest-test.ts
+++ b/test/ducktest-test.ts
@@ -11,6 +11,8 @@ testcase('make a new report', async () => {
         await s.testcase('empty test', () => { });
         await s.report(stream);
         assert.deepEqual(output, [
+            'TAP version 13',
+            '1..1',
             'ok - empty test'
         ]);
     });
@@ -21,10 +23,13 @@ testcase('make a new report', async () => {
         });
         await s.report(stream);
         assert.deepEqual(output, [
-            '# failing test',
+            'TAP version 13',
+            '1..1',
+            '[failing test]',
             '    not ok - failure',
             '      ---',
             '      ...',
+            '    1..1',
             'not ok - failing test'
         ]);
     });
@@ -36,9 +41,12 @@ testcase('make a new report', async () => {
         });
         await s.report(stream);
         assert.deepEqual(output, [
-            '# passing test',
+            'TAP version 13',
+            '1..1',
+            '[passing test]',
             '    ok - subcase one',
             '    ok - subcase two',
+            '    1..2',
             'ok - passing test'
         ]);
     });
@@ -52,13 +60,17 @@ testcase('make a new report', async () => {
         });
         await s.report(stream);
         assert.deepEqual(output, [
-            '# test',
-            '    # failing subcase',
+            'TAP version 13',
+            '1..1',
+            '[test]',
+            '    [failing subcase]',
             '        not ok - failure',
             '          ---',
             '          ...',
+            '        1..1',
             '    not ok - failing subcase',
             '    ok - empty subcase',
+            '    1..2',
             'not ok - test'
         ]);
     });
@@ -73,12 +85,15 @@ testcase('make a new report', async () => {
         });
         await s.report(stream);
         assert.deepEqual(output, [
-            '# test',
+            'TAP version 13',
+            '1..1',
+            '[test]',
             '    not ok - failure',
             '      ---',
             '      ...',
             '    ok - failing subcase # SKIP enclosing case failed',
             '    ok - empty subcase # SKIP enclosing case failed',
+            '    1..3',
             'not ok - test'
         ]);
     });
@@ -90,7 +105,9 @@ testcase('make a new report', async () => {
         });
         await s.report(stream);
         assert.deepEqual(output, [
-            '# test',
+            'TAP version 13',
+            '1..1',
+            '[test]',
             '    # message',
             'Bail out! cause'
         ]);
@@ -105,8 +122,10 @@ testcase('make a new report', async () => {
         });
         await s.report(stream);
         assert.deepEqual(output, [
-            '# test',
-            '    # subcase',
+            'TAP version 13',
+            '1..1',
+            '[test]',
+            '    [subcase]',
             '        # message',
             'Bail out! cause'
         ]);

--- a/test/tap-output-test.ts
+++ b/test/tap-output-test.ts
@@ -4,18 +4,20 @@ import { tap, Ordering, Stream, Reporter } from '../dist/tap-output.js';
 
 const assert: typeof strict = assertions.silence(strict);
 
-testcase('start a report', async () => {
+testcase('start a report without a plan', async () => {
     const output: string[] = [];
     const stream: Stream = lines => {
         for (const line of lines.split('\n')) {
             output.push(line);
         }
     };
-    const report = tap(stream);
+    const report = tap(stream).beginReport();
 
     subcase('end the report', () => {
         report.end();
         assert.deepEqual(output, [
+            'TAP version 13',
+            '1..0'
         ]);
     });
 
@@ -23,23 +25,28 @@ testcase('start a report', async () => {
         report.diagnostic('one\ntwo\nthree');
         report.end();
         assert.deepEqual(output, [
+            'TAP version 13',
             '# one',
             '# two',
-            '# three'
+            '# three',
+            '1..0'
         ]);
     });
 
     subcase('emit multi-line diagnostic from subcase', () => {
-        const subtest = report.beginSubtest('subtest');
+        const subtest = report.beginSubsection('subtest');
         subtest.diagnostic('one\ntwo\nthree');
         subtest.end();
         report.end();
         assert.deepEqual(output, [
-            '# subtest',
+            'TAP version 13',
+            '[subtest]',
             '    # one',
             '    # two',
             '    # three',
-            'ok - subtest'
+            '    1..0',
+            'ok - subtest',
+            '1..1'
         ]);
     });
 
@@ -47,7 +54,9 @@ testcase('start a report', async () => {
         stream('stream output')
         report.end();
         assert.deepEqual(output, [
-            'stream output'
+            'TAP version 13',
+            'stream output',
+            '1..0'
         ]);
     });
 });


### PR DESCRIPTION
- added optional plan for number of tests, and included plan output
for TAP report, automatically counting and putting at end if not
given. This fixes #17

- changed format for the diagnostic line that introduces a subtest.
Switched it from a diagnostic to `[description]` to make it more
consistent with the plan for concurrent subtests as per #1. This
is still forwards compatible with existing TAP parsers.

- added TAP version line at start of report output.

This commit also includes some refinement of Stream/Reporter/Report
API; now we don't always assume that a report must be associated
with an output stream. It's totally possible that this isn't always
the case!