### PR TITLE
Fixes #24 - automatic tagging retriggers CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,11 @@ jobs:
   tag_version:
     runs-on: ubuntu-latest
     needs: test
-    if: (github.ref == 'refs/heads/main') && (github.event_name == 'push')
+    if: (needs.test.result == 'success') && (github.event_name == 'push') && (github.ref == 'refs/heads/main')
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.DRONE_TOKEN }}
       - uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -45,7 +47,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: test
-    if: (needs.test.result == 'success') && startsWith(github.ref, 'refs/tags')
+    if: (needs.test.result == 'success') && (github.event_name == 'push') && startsWith(github.ref, 'refs/tags')
     environment:
       name: release
     steps:


### PR DESCRIPTION
Added secret with PAT for bot account to commit the automatic tag.

GITHUB_TOKEN can't be used for this, as per https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow