### PR TITLE
Fixes #26 - install before build in publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - '**'
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+      - 'v[0-9]+.[0-9]+.[0-9]+-**'
   pull_request:
     branches:
       - '**'
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install
+      - run: npm ci
       - run: npm run build
       - run: npm test
   tag_version:
@@ -56,6 +56,8 @@ jobs:
         with:
           node-version: 16
           registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -5,10 +5,9 @@
   "main": "ducktest",
   "type": "module",
   "scripts": {
-    "build": "tsc --build src test",
+    "build": "tsc --build src",
     "test": "tsc --build test && node tmp/tests.js",
-    "start": "tsc --build src && node dist/ducktest.js",
-    "prepublishOnly": "npm run build"
+    "start": "tsc --build src && node dist/ducktest.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cleaned up npm scripts and CI scripts a little.
- Removed prepublishOnly script as there's not much that needs to
be done, so rather than bundling lifecycles together in ways that
may be non-obvious, just run them all at the use site.
- replace npm install with npm ci in github workflows
- included install step before publish in publish workflow