### PR TITLE
fixes #33 - version tag and publish jobs only run on original repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,11 @@ jobs:
   tag_version:
     runs-on: ubuntu-latest
     needs: test
-    if: (needs.test.result == 'success') && (github.event_name == 'push') && (github.ref == 'refs/heads/main')
+    if: |
+      (github.repository_owner == 'StrangeSkies') &&
+      (needs.test.result == 'success') &&
+      (github.event_name == 'push') &&
+      (github.ref == 'refs/heads/main')
     steps:
       - uses: actions/checkout@v2
         with:
@@ -49,7 +53,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: test
-    if: (needs.test.result == 'success') && (github.event_name == 'push') && startsWith(github.ref, 'refs/tags')
+    if: |
+      (github.repository_owner == 'StrangeSkies') &&
+      (needs.test.result == 'success') &&
+      (github.event_name == 'push') &&
+      startsWith(github.ref, 'refs/tags')
     environment:
       name: release
     steps:


### PR DESCRIPTION
version tag job was failing on forks when it really just shouldn't
run at all. This fixes that.