### PR TITLE
Factor out a possibly-synchronous PromiseLike impl

### DIFF
--- a/src/commitment.ts
+++ b/src/commitment.ts
@@ -1,0 +1,50 @@
+export type SyncAsync<T = void> = PromiseLike<T> | T;
+class Commitment<T = void> implements PromiseLike<T> {
+    #value: () => SyncAsync<T>;
+
+    constructor(value: () => SyncAsync<T>) {
+        let result: SyncAsync<T> | undefined;
+        this.#value = () => (result = result || value());
+    }
+
+    then<R1 = T, R2 = never>(onfulfilled?: ((value: T) => SyncAsync<R1>) | undefined | null, onrejected?: ((reason: unknown) => SyncAsync<R2>) | undefined | null): Commitment<R1 | R2> {
+        const fulfill = onfulfilled ?? (t => t as unknown as (SyncAsync<R1>));
+        const reject = onrejected ?? (e => { throw e; });
+        return new Commitment(() => {
+            let result: SyncAsync<T>;
+            try {
+                result = this.#value();
+            } catch (e) {
+                return reject(e);
+            }
+            return (result && 'then' in result)
+                ? result.then(fulfill, reject)
+                : fulfill(result as T);
+        });
+    }
+
+    catch<R = never>(onrejected?: ((reason: unknown) => R | PromiseLike<R>) | undefined | null): Commitment<T | R> {
+        if (!onrejected)
+            return this;
+        return this.then(null, onrejected);
+    }
+
+    finally(onfinally?: (() => void) | undefined | null): Commitment<T> {
+        if (!onfinally)
+            return this;
+        return this.then(t => {
+            onfinally();
+            return t;
+        }, e => {
+            onfinally();
+            throw e;
+        });
+    }
+
+    honour() {
+        return this.#value();
+    }
+}
+export function commit(): Commitment<void> {
+    return new Commitment(() => void null);
+}


### PR DESCRIPTION
We support both sycn and async tests. But if all our internal APIs
return normal promises then synchronous tests end up running async,
which is probably unexpected for users and is bad ergonomics. So
we have a few utility functions, `syncAsyncChain`, `syncAsyncCatch`,
etc. to operate on (T | Promise<T>), and behave synchronously when
possible.

This was messy and difficult to use, so instead we introduce a
PromiseLike class, Commitment, which exposes the same thing through
then, catch, finally. This makes code look more like idiomatic
Javascript, and makes everything easier to read.